### PR TITLE
Ignore deleted messages in verification channel

### DIFF
--- a/events/messageDelete.js
+++ b/events/messageDelete.js
@@ -10,6 +10,7 @@ const name = "messageDelete";
  */
 async function handle(client, message) {
     if (!message.guild) return;
+    if (message.channelId == client.config.channels.verificate) return;
     const embed = new MessageEmbed()
         .setTitle("Gelöschte Nachricht")
         .setColor(0xedbc5d)


### PR DESCRIPTION
When the channel ID the message got deleted in is the channel ID of the verification channel the log Routine gets canceled.