### PR TITLE
Fixed whitespace for the new member DM message

### DIFF
--- a/events/newMember.js
+++ b/events/newMember.js
@@ -5,8 +5,8 @@
 export async function handle(client, member) {
     member.send({
         content: `Willkommen auf Blizzor's Community Server.
-        Damit du auf dem Server freigeschalten wirst, musst du den Befehl ${client.config.prefix}zz verwenden.
-        Bitte gib diesen Befehl im Channel #freischalten ein.`,
+Damit du auf dem Server freigeschalten wirst, musst du den Befehl ${client.config.prefix}zz verwenden.
+Bitte gib diesen Befehl im Channel #freischalten ein.`,
     });
 }
 export const disabled = false;


### PR DESCRIPTION
![Screenshot 2024-05-01 183130](https://github.com/Blizzorganization/BlizzbotJS/assets/71138238/9217e430-1193-40f1-9a77-abfe0b989c59)

The multiline string was using two tab spaces which made the DM look weird when being sent.